### PR TITLE
Add --onlyChanges option for tests

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.0.0", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.0.1", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.0.2", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.1.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.0.1", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.0.2", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
@@ -24,6 +24,8 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 import org.savantbuild.dep.domain.ArtifactID
 import org.savantbuild.domain.Project
@@ -73,6 +75,12 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
    *   groovyTestNG.test(groups: ["unit", "performance"])
    * </pre>
    *
+   * Supported command line options:
+   *  --onlyFailed    only runs test that failed on previous test run
+   *  --onlyChanges   only run tests for java classes and test classes changed on this branch
+   *    --n=D         only look at last D commits
+   *  --keepXml       keep the testNG xml file
+   *
    * @param attributes The named attributes.
    */
   void test(Map<String, Object> attributes) {
@@ -104,13 +112,19 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
     process.consumeProcessOutput(System.out, System.err)
 
     int result = process.waitFor()
-    Files.delete(xmlFile)
+    if (runtimeConfiguration.switches.booleanSwitches.contains("keepXml")) {
+      Path testSuite = project.directory.resolve("build/test/${xmlFile.fileName.toString()}")
+      Files.copy(xmlFile, testSuite)
+      output.infoln("TestNG configuration saved in: $testSuite")
+    } else {
+      Files.delete(xmlFile)
+    }
     if (result != 0) {
       // Keep a copy of the last set of test results when there is a failure.
       Path testResults = project.directory.resolve("build/test-reports/testng-results.xml")
       if (testResults.toFile().exists()) {
         Path target = getLastTestResultsPath()
-        Files.deleteIfExists(target);
+        Files.deleteIfExists(target)
         Files.createDirectories(target.getParent())
         Files.createFile(target)
         Files.copy(testResults,
@@ -139,6 +153,23 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
       } else {
         output.infoln("No test results found from a prior test run. File not found [" + testResults.toString() + "].")
       }
+    } else if (runtimeConfiguration.switches.booleanSwitches.contains("onlyChanges")) {
+      output.infoln("Only run tests for changed files (⚠️ misses changes in dependencies).")
+      String numberCommitsFlag = ""
+      if (runtimeConfiguration.switches.valueSwitches.containsKey("n")) {
+        numberCommitsFlag = "-n " + runtimeConfiguration.switches.values("n").first()
+      }
+      String committedChanges = "git log --name-only --no-merges --pretty=oneline $numberCommitsFlag origin..HEAD".execute().text
+      String uncommittedChanges = "git diff -u --name-only HEAD".execute().text
+
+      processGitOutput(committedChanges, classNames);
+      processGitOutput(uncommittedChanges, classNames);
+
+      List<String> dashTestFlags = new ArrayList<>()
+      for (String s : classNames) {
+        dashTestFlags.add("--test=" + s)
+      }
+      output.infoln("Found [" + classNames.size() + "] tests to run from changed files. Equivalent to running:\nsb test " + String.join(" ", dashTestFlags))
     } else {
       // Normal test execution, collect all tests
       project.publications.group("test").each { publication ->
@@ -274,4 +305,43 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
     String tmpDir = System.getProperty("java.io.tmpdir")
     return Paths.get(tmpDir).resolve(project.name + "/test-reports/last/testng-results.xml")
   }
+
+  /**
+   * Process terse git output into a list of java test classes
+   * @param changes     output from git
+   * @param testClasses set of classes we'll add to
+   */
+  private static void processGitOutput(String changes, Set<String> testClasses) {
+    Pattern testFilePattern = Pattern.compile("src/test/java/(.*Test).java")
+    Pattern mainFilePattern = Pattern.compile("src/main/java/(.*).java")
+
+    for (String change : changes.lines()) {
+      Matcher testMatcher = testFilePattern.matcher(change)
+      if (testMatcher.matches()) {
+        // it's a java test file
+        String testFile = testMatcher.group(0)
+
+        // ensure it still exists
+        if (Files.exists(Paths.get(testFile))) {
+          String classPathFile = testMatcher.group(1)
+          String testClass = classPathFile.replaceAll("/", ".")
+          testClasses.add(testClass)
+        }
+      } else {
+        Matcher mainMatcher = mainFilePattern.matcher(change)
+        if (mainMatcher.matches()) {
+          // it's a java file, look for a corresponding test
+          String file = mainMatcher.group(1)
+          String testClass = file.replaceAll("/", ".") + "Test"
+          if (!testClasses.contains(testClass)) {
+            String testFile = "src/test/java/" + file + "Test.java"
+            if (Files.exists(Paths.get(testFile))) {
+              testClasses.add(testClass)
+            }
+          }
+        }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
### Problem

Sometimes I only want to test what I've recently changed and not wait for all the tests to run.

### Solution

Add new command line switch, `--onlyChanges`.  This uses git to check what's changed locally and on your branch.  Any files matching `*Test.java` (or main classes having a corresponding Test) will be run.  By default, it will attempt `gh pr diff` to find changes.  If a PR isn't created yet, it will fall back to basically `git diff --no-merges origin..HEAD`

An additional argument, `--commitRange=<commit>` can be supplied to tell `git diff` what to look at.  

E.g., `sb test --onlyChanges --commitRange=HEAD~3` will look at what changed locally and in the last 3 commits.

Another new option, `--keepXML`, can be supplied to keep the testNG XML file.  This file can be used in IntelliJ to run the specific test suite that was just run.

### Reviewer Notes

This PR change can be run locally be pulling it, running `sb int`, and then updating your project's `build.savant` to have:
```
javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.1.0-{integration}")
```