### PR TITLE
Add Jacoco code coverage support

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -41,7 +41,7 @@ project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.1.0", 
       dependency(id: "org.savantbuild:savant-io:${savantVersion}")
       dependency(id: "org.savantbuild.plugin:dependency:${savantVersion}")
       dependency(id: "org.savantbuild.plugin:file:${savantVersion}")
-      def jacocoVersion = "0.8.12"
+      def jacocoVersion = "0.8.13"
       dependency(id: "org.jacoco:org.jacoco.agent:${jacocoVersion}")
       dependency(id: "org.jacoco:org.jacoco.core:${jacocoVersion}")
       dependency(id: "org.jacoco:org.jacoco.report:${jacocoVersion}")

--- a/build.savant
+++ b/build.savant
@@ -41,6 +41,10 @@ project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.1.0", 
       dependency(id: "org.savantbuild:savant-io:${savantVersion}")
       dependency(id: "org.savantbuild.plugin:dependency:${savantVersion}")
       dependency(id: "org.savantbuild.plugin:file:${savantVersion}")
+      def jacocoVersion = "0.8.12"
+      dependency(id: "org.jacoco:org.jacoco.agent:${jacocoVersion}")
+      dependency(id: "org.jacoco:org.jacoco.core:${jacocoVersion}")
+      dependency(id: "org.jacoco:org.jacoco.report:${jacocoVersion}")
     }
     group(name: "test-compile", export: false) {
       dependency(id: "org.testng:testng:7.8.0")

--- a/build.savant
+++ b/build.savant
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.1.0", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.2.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/java-testng-plugin.iml
+++ b/java-testng-plugin.iml
@@ -271,33 +271,33 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.agent/0.8.13/org.jacoco.agent-0.8.13.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.agent/0.8.13/org.jacoco.agent-0.8.13-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.report/0.8.12/org.jacoco.report-0.8.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.report/0.8.13/org.jacoco.report-0.8.13.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.report/0.8.12/org.jacoco.report-0.8.12-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.report/0.8.13/org.jacoco.report-0.8.13-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.core/0.8.12/org.jacoco.core-0.8.12.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.core/0.8.13/org.jacoco.core-0.8.13.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.core/0.8.12/org.jacoco.core-0.8.12-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.core/0.8.13/org.jacoco.core-0.8.13-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -392,33 +392,33 @@
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.7/asm-9.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.8.0/asm-9.8.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.7.0/asm-9.7.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.8.0/asm-9.8.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-commons/9.7/asm-commons-9.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-commons/9.8.0/asm-commons-9.8.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-commons/9.7.0/asm-commons-9.7.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-commons/9.8.0/asm-commons-9.8.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-tree/9.7/asm-tree-9.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-tree/9.8.0/asm-tree-9.8.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-tree/9.7.0/asm-tree-9.7.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-tree/9.8.0/asm-tree-9.8.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/java-testng-plugin.iml
+++ b/java-testng-plugin.iml
@@ -268,6 +268,39 @@
     <orderEntry type="module" module-name="dependency-plugin" />
     <orderEntry type="module" module-name="file-plugin" />
     <orderEntry type="module" module-name="savant-io" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.report/0.8.12/org.jacoco.report-0.8.12.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.report/0.8.12/org.jacoco.report-0.8.12-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.core/0.8.12/org.jacoco.core-0.8.12.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/jacoco/org.jacoco.core/0.8.12/org.jacoco.core-0.8.12-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
@@ -315,17 +348,6 @@
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.2.0/asm-9.2.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.2.0/asm-9.2.0-src.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="RUNTIME">
-      <library>
-        <CLASSES>
           <root url="jar://$MODULE_DIR$/.savant/cache/org/apache/ant/ant/1.9.4/ant-1.9.4.jar!/" />
         </CLASSES>
         <JAVADOC />
@@ -364,6 +386,39 @@
         <JAVADOC />
         <SOURCES>
           <root url="jar://$MODULE_DIR$/.savant/cache/org/tukaani/xz/1.4.0/xz-1.4.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.7/asm-9.7.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.7.0/asm-9.7.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-commons/9.7/asm-commons-9.7.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-commons/9.7.0/asm-commons-9.7.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-tree/9.7/asm-tree-9.7.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm-tree/9.7.0/asm-tree-9.7.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
@@ -401,7 +401,7 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
     def visitor = formatter.createVisitor(new FileMultiReportOutput(reportDirectory))
     visitor.visitInfo(loader.sessionInfoStore.infos,
         loader.executionDataStore.contents)
-    def sourceLocator = new MultiSourceFileLocator(4);
+    def sourceLocator = new MultiSourceFileLocator(4)
     sourceLocator.add(new DirectorySourceFileLocator(new File(project.directory.toFile(), "src/main/java"),
         "utf-8",
         4))

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
@@ -28,6 +28,7 @@ import java.util.jar.JarFile
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import org.jacoco.agent.AgentJar
 import org.jacoco.core.analysis.Analyzer
 import org.jacoco.core.tools.ExecFileLoader
 import org.jacoco.core.analysis.CoverageBuilder
@@ -121,6 +122,9 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
     process.consumeProcessOutput(System.out, System.err)
 
     int result = process.waitFor()
+    if (settings.codeCoverage) {
+      produceCodeCoverageReports()
+    }
     if (runtimeConfiguration.switches.booleanSwitches.contains("keepXML")) {
       Path testSuite = project.directory.resolve("build/test/${xmlFile.fileName.toString()}")
       Files.copy(xmlFile, testSuite)
@@ -405,7 +409,7 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
   }
 
   File getCodeCoverageFile() {
-    project.directory.resolve("build/jacoco.exec").toFile()
+    project.directory.resolve("build/jacoco.exec").toAbsolutePath().toFile()
   }
 
   String getCodeCoverageArguments() {

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
@@ -28,6 +28,13 @@ import java.util.jar.JarFile
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import org.jacoco.core.analysis.Analyzer
+import org.jacoco.core.tools.ExecFileLoader
+import org.jacoco.core.analysis.CoverageBuilder
+import org.jacoco.report.DirectorySourceFileLocator
+import org.jacoco.report.FileMultiReportOutput
+import org.jacoco.report.MultiSourceFileLocator
+import org.jacoco.report.html.HTMLFormatter
 import org.savantbuild.dep.domain.ArtifactID
 import org.savantbuild.domain.Project
 import org.savantbuild.io.FileTools

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
@@ -390,6 +390,7 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
     def coverageClassPath = dependencyPlugin.classpath {
       project.publications.group("main").each { publication -> path(location: publication.file.toAbsolutePath()) }
     }
+    // add each JAR from the Savant main publication group to be analyzed
     coverageClassPath.paths.each { p ->
       analyzer.analyzeAll(p.toFile())
     }

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGSettings.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGSettings.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ class JavaTestNGSettings {
   Path reportDirectory = Paths.get("build/test-reports")
 
   List<String> listeners = []
+
+  boolean codeCoverage
 
   List<Map<String, Object>> dependencies = [
       [group: "provided", transitive: true, fetchSource: false, transitiveGroups: ["provided", "compile", "runtime"]],

--- a/src/test/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPluginTest.groovy
+++ b/src/test/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPluginTest.groovy
@@ -114,6 +114,19 @@ class JavaTestNGPluginTest {
   }
 
   @Test
+  void test_coverage() throws Exception {
+    JavaTestNGPlugin plugin = new JavaTestNGPlugin(project, new RuntimeConfiguration(), output)
+    plugin.settings.javaVersion = "1.8"
+    plugin.settings.codeCoverage = true
+
+    plugin.test()
+    assertTestsRan("org.savantbuild.test.MyClassTest", "org.savantbuild.test.MyClassIntegrationTest", "org.savantbuild.test.MyClassUnitTest")
+
+    plugin.test(null)
+    assertTestsRan("org.savantbuild.test.MyClassTest", "org.savantbuild.test.MyClassIntegrationTest", "org.savantbuild.test.MyClassUnitTest")
+  }
+
+  @Test
   void skipTests() throws Exception {
     RuntimeConfiguration runtimeConfiguration = new RuntimeConfiguration()
     runtimeConfiguration.switches.booleanSwitches.add("skipTests")

--- a/src/test/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPluginTest.groovy
+++ b/src/test/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPluginTest.groovy
@@ -124,6 +124,10 @@ class JavaTestNGPluginTest {
 
     plugin.test(null)
     assertTestsRan("org.savantbuild.test.MyClassTest", "org.savantbuild.test.MyClassIntegrationTest", "org.savantbuild.test.MyClassUnitTest")
+
+    // assert our code coverage report exists
+    assertTrue(Files.isDirectory(projectDir.resolve("test-project/build/coverage-reports")))
+    assertTrue(Files.isRegularFile(projectDir.resolve("test-project/build/coverage-reports/index.html")))
   }
 
   @Test


### PR DESCRIPTION
1. If `codeCoverage` is enabled on the plugin settings (defaults to `false`), a code coverage report will be generated at `build/coverage-reports`
2. The coverage agent, when the setting is enabled, is temporarily extracted from the dependencies, via a Jacoco convenience method (`AgentJar.extractToTempLocation`) and then passed along as a command line JVM argument (`-javaagent`).