### PR TITLE
Fix issue with no `jvmArguments`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             17
       - name: setup groovy
         run: |
-          GROOVY_VERSION="4.0.29"
+          GROOVY_VERSION="4.0.22"
           curl -OL https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${GROOVY_VERSION}.zip
           unzip apache-groovy-binary-${GROOVY_VERSION}.zip
           echo "GROOVY_HOME=$(pwd)/groovy-${GROOVY_VERSION}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
+            8
             21
             17
       - name: setup groovy
@@ -36,6 +37,7 @@ jobs:
           echo "${SAVANT_PATH}" >> $GITHUB_PATH
           mkdir -p ~/.savant/plugins
           cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
+          1.8=${JAVA_HOME_8_X64}
           17=${JAVA_HOME_17_X64}
           21=${JAVA_HOME_21_X64}
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+---
+name: build
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: /usr/bin/bash -l -e -o pipefail {0}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: |
+            21
+            17
+      - name: savant setup
+        run: |
+          curl -O https://repository.savantbuild.org/org/savantbuild/savant-core/2.0.2/savant-2.0.2.tar.gz
+          tar xzvf savant-2.0.2.tar.gz
+          savant-2.0.2/bin/sb --version
+          SAVANT_PATH=$(realpath -s "./savant-2.0.2/bin")
+          echo "${SAVANT_PATH}" >> $GITHUB_PATH
+          mkdir -p ~/.savant/plugins
+          # For now, using the JDK that comes on the GHA runner
+          cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
+          17=${JAVA_HOME_17_X64}
+          21=${JAVA_HOME_21_X64}
+          EOF
+          echo "~/.savant/plugins/org.savantbuild.plugin.java.properties"
+          cat ~/.savant/plugins/org.savantbuild.plugin.java.properties
+      # Takes some time, better to tell difference between this step and actual test run time
+      - name: compile/pull Savant dependencies
+        run: |
+          $JAVA_HOME/bin/java -version
+          sb --version
+          sb clean compile
+      - name: run tests/integrate
+        run: |
+          sb clean int
+      - name: capture reports
+        uses: actions/upload-artifact@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          name: testng_reports
+          path: build/test-reports/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           sb clean compile
       - name: run tests/integrate
         run: |
-          sb clean int
+          sb clean test --debug
       - name: capture reports
         uses: actions/upload-artifact@v4
         if: success() || failure() # always run even if the previous step fails

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,13 @@ jobs:
           java-version: |
             21
             17
+      - name: setup groovy
+        run: |
+          GROOVY_VERSION="4.0.29"
+          curl -OL https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${GROOVY_VERSION}.zip
+          unzip apache-groovy-binary-${GROOVY_VERSION}.zip
+          echo "GROOVY_HOME=$(pwd)/groovy-${GROOVY_VERSION}" >> $GITHUB_ENV
+
       - name: savant setup
         run: |
           curl -O https://repository.savantbuild.org/org/savantbuild/savant-core/2.0.2/savant-2.0.2.tar.gz
@@ -28,13 +35,17 @@ jobs:
           SAVANT_PATH=$(realpath -s "./savant-2.0.2/bin")
           echo "${SAVANT_PATH}" >> $GITHUB_PATH
           mkdir -p ~/.savant/plugins
-          # For now, using the JDK that comes on the GHA runner
           cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
           17=${JAVA_HOME_17_X64}
           21=${JAVA_HOME_21_X64}
           EOF
           echo "~/.savant/plugins/org.savantbuild.plugin.java.properties"
           cat ~/.savant/plugins/org.savantbuild.plugin.java.properties
+          cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.groovy.properties
+          4.0=${GROOVY_HOME}
+          EOF
+          echo "~/.savant/plugins/org.savantbuild.plugin.groovy.properties"
+          cat ~/.savant/plugins/org.savantbuild.plugin.groovy.properties
       # Takes some time, better to tell difference between this step and actual test run time
       - name: compile/pull Savant dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           sb clean compile
       - name: run tests/integrate
         run: |
-          sb clean test --debug
+          sb clean test
       - name: capture reports
         uses: actions/upload-artifact@v4
         if: success() || failure() # always run even if the previous step fails

--- a/build.savant
+++ b/build.savant
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.2.1", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "java-testng", version: "2.2.2", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/java/testng/JavaTestNGPlugin.groovy
@@ -118,7 +118,9 @@ class JavaTestNGPlugin extends BaseGroovyPlugin {
     String command = "${javaPath} ${settings.jvmArguments} ${classpath.toString("-classpath ")}${jacocoArgs} org.testng.TestNG -d ${settings.reportDirectory} ${settings.testngArguments} ${xmlFile}"
     output.debugln("Running command [%s]", command)
 
-    Process process = new ProcessBuilder(command.split(" "))
+    // StringTokenizer handles multiple spaces, etc. for us (jvmArguments is optional)
+    def args = new StringTokenizer(command).toList() as List<String>
+    Process process = new ProcessBuilder(args)
     // need to use inheritIO as opposed to process.consumeProcessOutput(System.out, System.err) because that will
     // cause buffering that hides test output that does not end with a carriage return
     .inheritIO()


### PR DESCRIPTION
### Problems

1. Previous change to accommodate console output broke cases where `settings.jvmArguments` is not set.
2. Tests were failing and we didn't know it.

### Solutions
1. Use `StringTokenizer` to handle more whitespace cases (this is what Groovy's `command.execute`, which was previously used here, uses)
2. Add a GHA workflow for tests